### PR TITLE
add microsecond in timestamp representation, for PHP 7.1

### DIFF
--- a/src/Authentication/Timestamp.php
+++ b/src/Authentication/Timestamp.php
@@ -69,6 +69,6 @@ class Timestamp
      */
     public function __toString()
     {
-        return $this->timestamp->format('Ymd\TH:i:sO');
+        return $this->timestamp->format('Ymd\TH:i:s.uO');
     }
 }

--- a/tests/Authentication/TimestampTest.php
+++ b/tests/Authentication/TimestampTest.php
@@ -28,7 +28,7 @@ class TimestampTest extends \PHPUnit_Framework_TestCase
     {
         $timestamp = new \Akamai\Open\EdgeGrid\Authentication\Timestamp();
 
-        $check = \DateTime::createFromFormat('Ymd\TH:i:sO', (string) $timestamp, new \DateTimeZone('UTC'));
+        $check = \DateTime::createFromFormat('Ymd\TH:i:s.uO', (string) $timestamp, new \DateTimeZone('UTC'));
         $this->assertEquals($check, \PHPUnit_Framework_Assert::readAttribute($timestamp, 'timestamp'));
     }
 


### PR DESCRIPTION
Discovered in Fedora QA, since PHP 7.1.0RC6
See: https://apps.fedoraproject.org/koschei/package/php-akamai-open-edgegrid-auth?collection=f26

```
PHPUnit 5.6.2 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.1.0RC6
Configuration: /builddir/build/BUILD/AkamaiOPEN-edgegrid-php-1617cf4bdeba7b5c46a1d55bb969d0e45c7f52f5/phpunit.xml
..F...................................                            38 / 38 (100%)
Time: 2.04 seconds, Memory: 4.00MB
There was 1 failure:
1) Akamai\Open\EdgeGrid\Tests\Client\Authentication\TimestampTest::testTimestampFormat
Failed asserting that two DateTime objects are equal.
```

This simple fix add microsecond in timestamp converted to string.
But I don't know if some usage to this library will be broken by this change.
So please review.

/cc @siwinski
